### PR TITLE
Upgrade angstrom minimal version to 0.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	dune build @install
 
 install-deps:
-	opam install --deps-only ./semver2.opam
+	opam install --deps-only --with-test ./semver2.opam
 
 test:
 	dune runtest
@@ -20,4 +20,3 @@ clean:
 
 doc:
 	dune build @doc
-

--- a/README.md
+++ b/README.md
@@ -14,14 +14,28 @@ Please refer to the module documentation for its API.
 
 ## Local development
 
-An OCaml and Opam environment is required. Library dependencies can be installed with:
+The following dependencies are required:
+
+-   ocaml
+-   opam
+-   m4
+-   pkg-config
+
+Opam needs to be initialized:
+
+    $ opam init
+
+Library dependencies can be installed with:
 
     $ make install-deps
+
+Make sure to have an updated shell environment:
+
+    $ eval $(opam env)
 
 Then you can run the test suite with:
 
     $ make test
-
 
 ## Contributing
 
@@ -33,7 +47,6 @@ Contributions are welcome in the form of issues or pull requests. Please remembe
 
 ## Copyright and Licensing
 
-(C) 2019 Dividat AG.
+(C) 2020 Dividat AG.
 
 Published under MIT license.
-

--- a/lib/semver.ml
+++ b/lib/semver.ml
@@ -56,20 +56,19 @@ let identifier_list id_parser sep =
   char sep *> sep_by1 dot id_parser <|> return []
 
 let version_parser =
-  (lift4 mk_version
+  lift4 mk_version
      nat
      (dot *> nat)
      (dot *> nat)
      (identifier_list prerelease_identifier '-')
-   <*> (identifier_list base_identifier '+'))
-  <* end_of_input
+   <*> (identifier_list base_identifier '+')
 
 let from_parts major minor patch prerelease build =
   let check_prerelease_item s =
-    parse_string (prerelease_identifier <* end_of_input) s |> isOk
+    parse_string ~consume:All prerelease_identifier s |> isOk
   in
   let check_build_item s =
-    parse_string (base_identifier <* end_of_input) s |> isOk
+    parse_string ~consume:All base_identifier s |> isOk
   in
   if major >= 0 && minor >= 0 && patch >= 0 &&
      List.for_all check_prerelease_item prerelease &&
@@ -79,12 +78,12 @@ let from_parts major minor patch prerelease build =
     None
 
 let of_string str =
-  match parse_string version_parser str with
+  match parse_string ~consume:All version_parser str with
   | Ok v -> Some v
   | Error _ -> None
 
 let is_valid str =
-  match parse_string version_parser str with
+  match parse_string ~consume:All version_parser str with
   | Ok _ -> true
   | Error _ -> false
 
@@ -103,7 +102,7 @@ let is_valid str =
    <https://semver.org/#spec-item-11>
 *)
 let compare_identifiers ia ib =
-  match parse_string (nat <* end_of_input) ia, parse_string (nat <* end_of_input) ib with
+  match parse_string ~consume:All nat ia, parse_string ~consume:All nat ib with
   | Ok na, Ok nb -> compare na nb
   | Ok _, _ -> -1
   | _, Ok _ -> 1

--- a/semver2.opam
+++ b/semver2.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/dividat/ocaml-semver/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.2.0"}
-  "angstrom" {>= "0.11.2"}
+  "angstrom" {>= "0.14.0"}
   "ounit" {with-test & >= "1.0.2"}
   "yojson" {with-test & >= "1.4.1"}
   "odoc" {with-doc}


### PR DESCRIPTION
Nixpkgs 20.09 is using angstrom 0.14.1.

https://github.com/NixOS/nixpkgs/blob/20.09/pkgs/development/ocaml-modules/angstrom/default.nix

From angstrom 0.14.0, `parse_string` requires the additional `consume` parameter, which is either `All` that requires the consumption of the all input, or `Prefix`.

Add the new `~consume:All` parameter when calling `parse_string`, and stop using the end_of_input parser.

Also, add some documentation.