### PR TITLE
Make versions printable and equality comparable.

### DIFF
--- a/lib/semver.ml
+++ b/lib/semver.ml
@@ -119,6 +119,9 @@ let rec compare_prerelease is_first pra prb =
     else
       compare_prerelease false ta tb
 
+let pp fmt version =
+  Format.pp_print_string fmt (to_string version)
+
 let compare a b =
   if a.major != b.major then
     compare a.major b.major
@@ -127,6 +130,9 @@ let compare a b =
   else if a.patch != b.patch then
     compare a.patch b.patch
   else compare_prerelease true a.prerelease b.prerelease
+
+let equal a b =
+  compare a b = 0
 
 let less_than a b =
   compare a b < 0

--- a/lib/semver.mli
+++ b/lib/semver.mli
@@ -35,3 +35,9 @@ val less_than : t -> t -> bool
 
 (** Return true if first has higher precedence than second. *)
 val greater_than : t -> t -> bool
+
+(** Return whether versions are equal *)
+val equal : t -> t -> bool
+
+(** Pretty print version *)
+val pp : Format.formatter -> t -> unit

--- a/lib_test/test_semver.ml
+++ b/lib_test/test_semver.ml
@@ -10,7 +10,9 @@ let valids, invalids, sorted =
 let test_valids () =
   let assert_iso v =
     match of_string v with
-    | Some v' -> assert_equal (to_string v') v
+    | Some v' ->
+       assert_equal (to_string v') v;
+       assert_equal (Format.asprintf "%a" Semver.pp v') v
     | None -> assert_failure ("valid version detected as invalid: " ^ v)
   in
   List.iter assert_iso valids


### PR DESCRIPTION
* `Semver.pp` makes version compatible with `Format`'s `%a`.
* `Semver.equal` makes it closer to many comparable module signature expectation, such as `Base.Comparable.S`.